### PR TITLE
#27 add filtering with pattern's type and associate algo & change Sel…

### DIFF
--- a/src/components/Select.tsx
+++ b/src/components/Select.tsx
@@ -11,6 +11,7 @@ interface SelectProps {
   label?: string;
   placeholder?: string;
   className?: string;
+  defaultValue?: Option;
 }
 
 const Select: React.FC<SelectProps> = ({
@@ -18,10 +19,12 @@ const Select: React.FC<SelectProps> = ({
   onSelect,
   label,
   placeholder = "Choisir une option",
-  className = ""
+  className = "",
+  defaultValue 
 }) => {
+
   const [isOpen, setIsOpen] = useState(false);
-  const [selected, setSelected] = useState<Option | null>(null);
+  const [selected, setSelected] = useState<Option | null>(defaultValue || null);
 
   const handleSelect = (option: Option) => {
     setSelected(option);
@@ -33,7 +36,6 @@ const Select: React.FC<SelectProps> = ({
     <div className={`relative w-full max-w-xs ${className}`}>
       {label && <label className="block mb-2 text-sm font-medium text-gray-700">{label}</label>}
       
-      {/* Bouton principal */}
       <button
         type="button"
         onClick={() => setIsOpen(!isOpen)}
@@ -52,7 +54,6 @@ const Select: React.FC<SelectProps> = ({
         </svg>
       </button>
 
-      {/* Menu déroulant */}
       {isOpen && (
         <ul className="absolute z-10 w-full mt-1 overflow-auto bg-white border border-gray-300 rounded-lg shadow-lg max-h-60 focus:outline-none">
           {options.map((option) => (

--- a/src/pages/Patterns.tsx
+++ b/src/pages/Patterns.tsx
@@ -5,42 +5,24 @@ import SearchBar, { SearchSuggestion } from "@/components/SearchBar";
 import PatternHeatmap from "@/components/PatternHeatmap";
 import { type PatternType } from "@/PatternType";
 
-const mockOptionsType: Option[] = [
-    { label: 'Anomaly', value: 'anomaly' },
-    { label: 'Nominal', value: 'nominal' },
-    { label: 'Noise', value: 'noise' },
-];
-
-const mockOptionsAlgos: Option[] = [
-    { label: 'Isolation Forest', value: 'isoforest' },
-    { label: 'Random Forest', value: 'ranforest' },
-    { label: 'DBSCAN', value: 'dbscan' },
-];
-
 const mockData: PatternType[] = [
     {
         id: 'Gaussian Distribution',
-        counts: { 
-            '[0-0.2[': 1, '[0.2-0.4[': 0, '[0.4-0.6[': 0, '[0.6-0.8[': 2, '[0.8-1.0]': 1 
-        },
+        counts: { '[0-0.2[': 1, '[0.2-0.4[': 0, '[0.4-0.6[': 0, '[0.6-0.8[': 2, '[0.8-1.0]': 1 },
         notebooks: { 'analysis_v1.ipynb': 0.6, 'experiment_A.ipynb': 0.4 },
         TypeAlgo: 'Isolation Forest',
         TypePattern: 'Distribution'
     },
     {
         id: 'Annealing and binary',
-        counts: { 
-            '[0-0.2[': 0, '[0.2-0.4[': 5, '[0.4-0.6[': 20, '[0.6-0.8[': 80, '[0.8-1.0]': 160 
-        },
+        counts: { '[0-0.2[': 0, '[0.2-0.4[': 5, '[0.4-0.6[': 20, '[0.6-0.8[': 80, '[0.8-1.0]': 160 },
         notebooks: { 'production_model.ipynb': 0.9 },
         TypeAlgo: 'Random Forest',
         TypePattern: 'Loading'
     },
     {
         id: 'Normalisation',
-        counts: { 
-            '[0-0.2[': 150, '[0.2-0.4[': 80, '[0.4-0.6[': 20, '[0.6-0.8[': 5, '[0.8-1.0]': 0 
-        },
+        counts: { '[0-0.2[': 150, '[0.2-0.4[': 80, '[0.4-0.6[': 20, '[0.6-0.8[': 5, '[0.8-1.0]': 0 },
         notebooks: { 'debug_session.ipynb': 0.6, 'old_version.ipynb': 0.4 },
         TypeAlgo: 'DBSCAN',
         TypePattern: 'Normalisation'
@@ -48,24 +30,48 @@ const mockData: PatternType[] = [
 ];
 
 export default function Patterns() {
+
     const [searchQuery, setSearchQuery] = useState('');
+    const [selectedType, setSelectedType] = useState<string>('');
+    const [selectedAlgo, setSelectedAlgo] = useState<string>('');
+
+    const typeOptions: Option[] = [
+        { label: 'Afficher tous les type', value: '' },
+        ...Array.from(new Set(mockData.map(d => d.TypePattern))).map(type => ({
+            label: type,
+            value: type
+        }))
+    ];
+
+    const algoOptions: Option[] = [
+        { label: 'Afficher tous les algos', value: '', },
+        ...Array.from(new Set(mockData.map(d => d.TypeAlgo))).map(algo => ({
+            label: algo,
+            value: algo
+        }))
+    ];
 
     const filteredData = mockData.filter((pattern) => {
         const query = searchQuery.toLowerCase();
-        if (!query) return true;
-        return (
+
+        const matchSearch = !query || (
             pattern.id.toLowerCase().includes(query) ||
             pattern.TypePattern.toLowerCase().includes(query) ||
             pattern.TypeAlgo.toLowerCase().includes(query)
         );
+
+        const matchType = selectedType === '' || pattern.TypePattern === selectedType;
+        const matchAlgo = selectedAlgo === '' || pattern.TypeAlgo === selectedAlgo;
+
+        return matchSearch && matchType && matchAlgo;
     });
 
-    const searchSuggestions: SearchSuggestion[] = searchQuery 
+    const searchSuggestions: SearchSuggestion[] = searchQuery
         ? filteredData.map(pattern => ({
             label: pattern.id,
             subLabel: `${pattern.TypePattern} • ${pattern.TypeAlgo}`,
             value: pattern.id
-          }))
+        }))
         : [];
 
     return (
@@ -74,10 +80,10 @@ export default function Patterns() {
                 logoUrl="https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSwt1HL9fRcwfyF4lzGkCREKMmUv7OVyYGftYlNCNxNuENKpOCJZNxywAsv3fYra7N7uUP1&s=10"
                 title="Galileo - Patterns"
             >
-                <button className="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600 transition-colors">
+                <button className="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600">
                     <a href="/storytelling">Storytelling</a>
                 </button>
-                <button className="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600 transition-colors">
+                <button className="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600">
                     <a href="/artefact">Artefact</a>
                 </button>
                 <button className="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600 transition-colors">
@@ -89,23 +95,25 @@ export default function Patterns() {
                 <div className="flex flex-row gap-6">
                     <div className="w-64">
                         <Select
-                            options={mockOptionsType}
-                            placeholder="Sélectionner un type"
-                            onSelect={(value) => console.log("Type:", value)}
+                            options={typeOptions}
+                            placeholder="Filtrer par type"
+                            defaultValue={typeOptions[0]}
+                            onSelect={(option) => setSelectedType(String(option.value))}
                         />
                     </div>
                     <div className="w-64">
                         <Select
-                            options={mockOptionsAlgos}
-                            placeholder="Sélectionner un algo"
-                            onSelect={(value) => console.log("Algo:", value)}
+                            options={algoOptions}
+                            placeholder="Filtrer par algo"
+                            defaultValue={algoOptions[0]}
+                            onSelect={(option) => setSelectedAlgo(String(option.value))}
                         />
                     </div>
                 </div>
 
                 <div className="flex-1 max-w-md relative">
-                    <SearchBar 
-                        placeholder="Rechercher (Nom, Type, Algo)..." 
+                    <SearchBar
+                        placeholder="Rechercher..."
                         onSearch={(value) => setSearchQuery(value)}
                         suggestions={searchSuggestions}
                         onSelectSuggestion={(value) => setSearchQuery(value)}
@@ -115,9 +123,9 @@ export default function Patterns() {
 
             <section className="flex-1 p-6 flex flex-col min-h-0">
                 <div className="bg-white rounded-xl shadow-lg p-4 flex-1 flex flex-col">
-                    <PatternHeatmap 
-                        title="Distribution des patterns par score" 
-                        data={filteredData} 
+                    <PatternHeatmap
+                        title={`Patterns (${filteredData.length})`}
+                        data={filteredData}
                         fullWidth
                         className="flex-1"
                     />


### PR DESCRIPTION
## Description
Ajout de la logique du filtrage via les composants déjà présent sur la page. On peux filtrer les patterns par type de pattern et l'algo associé au pattern

---

## Type de changement
(Coche ce qui s’applique)
- [ ] Bug fix
- [x] Nouvelle fonctionnalité
- [x] Refactor
- [ ] Tâche / maintenance
- [x] Documentation
- [ ] Autre, précisez

---

## Changements principaux
- Filtre des patterns affichés dans le graphique par type et par algo associé
- Ajout d'un paramètre sur le composant Select pour choisir l'option par défaut dans le select

---

## Impact
- [ ] Aucun impact majeur
- [x] Impact sur le code existant
- [ ] Impact sur la configuration / infra
- [x] Impact sur la documentation

Précisions si nécessaire :

---

## Checklist
- [x] Le code compile / fonctionne correctement
- [x] Les tests passent (ou non applicables)
- [ ] Le lint / format est respecté
- [x] La documentation a été mise à jour si nécessaire
- [x] Pas de breaking change non documenté

---

## Issue liée
Closes #27 

---

## Notes pour le reviewer
RaS
